### PR TITLE
Initial boot and deploy process

### DIFF
--- a/_BOOT/bin/bootstrap.py
+++ b/_BOOT/bin/bootstrap.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+from requests import Session
+from influxdb import InfluxDBClient
+import yaml
+import os
+
+
+class Bootstrap(object):
+    def __init__(self):
+        self._influx = Influx(username=self.secrets.get('influxdb_username'),
+                              password=self.secrets.get('influxdb_password'),
+                              database=self.secrets.get('influxdb_database'))
+        self._grafana = Grafana()
+
+    def bootstrap(self):
+        self._influx.bootstrap()
+        data_sources = [
+            {"name": "prometheus",
+             "type": "prometheus",
+             "url": "http://localhost:9090",
+             "access": "direct"},
+            {"name": "influxdb",
+             "type": "influxdb",
+             "url": "http://localhost:8086",
+             "access": "direct",
+             "database": self.secrets.get('influxdb_database'),
+             "password": self.secrets.get('influxdb_password'),
+             "username": self.secrets.get('influxdb_username')}]
+        for data_source in data_sources:
+            self._grafana.create_data_source(payload=data_source)
+        return True
+
+    @property
+    def secrets(self):
+        base_path = os.path.abspath(os.path.dirname('.'))
+        secret_file = '{}/home_assistant/config/secrets.yaml'.format(base_path)
+        _secrets = yaml.load(open(secret_file, 'r'))
+        return _secrets
+
+
+class Influx(object):
+    def __init__(self, username, password, database):
+        self._influx = InfluxDBClient()
+        self._username = username
+        self._password = password
+        self._database = database
+
+    def get_indices(self):
+        self._influx.get_list_database()
+
+    def bootstrap(self):
+        print("Creating Influx resources")
+        self._influx.create_database(dbname=self._database)
+        self._influx.create_user(username=self._username,
+                                 password=self._password)
+        self._influx.grant_privilege(privilege='ALL',
+                                     database=self._database,
+                                     username=self._username)
+        return True
+
+
+class Grafana(object):
+    def __init__(self, username='admin', password='admin'):
+        self._session = Session()
+        self._site = 'http://localhost:3000/api/datasources'
+        self._username = username
+        self._password = password
+
+    def create_data_source(self, payload):
+        print("Creating Grafana data source for: {}".format(payload.get('name')))
+        request = self._session.post(self._site,
+                                     auth=(self._username, self._password),
+                                     json=payload)
+        return request
+
+
+if __name__ == '__main__':
+    boot = Bootstrap()
+    boot.bootstrap()

--- a/_BOOT/scripts/bootstrap
+++ b/_BOOT/scripts/bootstrap
@@ -1,0 +1,23 @@
+#!/bin/bash
+cd $(dirname $0)/../..
+
+export WORKON_HOME=$(pwd)/.venv
+
+source $(which virtualenvwrapper.sh)
+if [ $? != 0 ]
+then
+  echo "Missing prerequisite virtualenvwrapper, bailing out"
+  exit 1
+fi
+
+if (! test -d "$WORKON_HOME/.home_automation")
+then
+  echo "Creating virtual env for .home_automation"
+  mkvirtualenv ".home_automation"
+fi
+
+echo "Working on virtualenv home_automation"
+source "$WORKON_HOME/.home_automation/bin/activate"
+
+echo "Installing python package requirements.."
+pip install -r requirements.txt

--- a/_BOOT/scripts/build
+++ b/_BOOT/scripts/build
@@ -1,0 +1,13 @@
+#!/bin/bash --login
+set -e
+cd $(dirname $0)/../..
+
+. _BOOT/scripts/bootstrap
+
+echo "Running docker compose"
+sudo docker-compose up -d
+
+# Need some time for dockers to boot up
+sleep 10
+
+python _BOOT/bin/bootstrap.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+PyYAML==3.12
+influxdb==5.0.0
+requests==2.18.4


### PR DESCRIPTION
This is an idea inspired by the cookiecutter templates and it is a tentative approach.

It creates Grafana data sources and InfluxDB user and database based on `secrets.yaml`. 
Grafana admin password is set to `admin` and it's something that just be read probably from `.env` file.
Also I'm not validating if Grafana or Influx resources are already created as they are a few HTTP calls but maybe something we can discuss.
Still pending the `node_exporter` part and change the ip on `prometheus.yml`. 
